### PR TITLE
refactored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ swarm.key
 feedback.log
 *.sqlite
 *.db
-
+CLAUDE.md
 vendor/
 go.work
 go.work.sum

--- a/agentfm-go/cmd/agentfm/main.go
+++ b/agentfm-go/cmd/agentfm/main.go
@@ -176,7 +176,9 @@ func main() {
 			pterm.Fatal.Println(err)
 		}
 		b := boss.New(node)
-		b.StartAPIServer(*apiPort)
+		if err := b.StartAPIServer(*apiPort); err != nil {
+			pterm.Fatal.Printfln("❌ API Gateway exited with error: %v", err)
+		}
 
 	} else {
 		pterm.Error.Println("Invalid mode. Use 'boss', 'worker', 'relay', 'api', 'test', or 'genkey'.")

--- a/agentfm-go/cmd/agentfm/main.go
+++ b/agentfm-go/cmd/agentfm/main.go
@@ -123,7 +123,9 @@ func main() {
 			}
 		}
 
-		err := worker.RunLocalTest(cfg, promptToUse)
+		testCtx, stopTest := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+		defer stopTest()
+		err := worker.RunLocalTest(testCtx, cfg, promptToUse)
 		if err != nil {
 			pterm.Fatal.Printfln("❌ Local test failed: %v", err)
 		}

--- a/agentfm-go/cmd/agentfm/main.go
+++ b/agentfm-go/cmd/agentfm/main.go
@@ -193,7 +193,8 @@ func setupHelpMenu() {
 			WithBackgroundStyle(pterm.NewStyle(pterm.BgCyan)).
 			WithTextStyle(pterm.NewStyle(pterm.FgBlack)).
 			Printfln("🚀 AGENTFM CLI v%s", version.AppVersion)
-		pterm.Info.Println("A global, peer-to-peer compute grid for containerized local AI.\n")
+		pterm.Info.Println("A global, peer-to-peer compute grid for containerized local AI.")
+		fmt.Println()
 
 		pterm.DefaultSection.Println("Flags & Configuration")
 

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -200,15 +200,30 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to connect to worker via DHT or Relay", http.StatusInternalServerError)
 		return
 	}
-	defer s.Close()
+
+	streamSuccess := false
+	defer func() {
+		if streamSuccess {
+			_ = s.Close()
+		} else {
+			_ = s.Reset()
+		}
+	}()
+
+	if err := s.SetWriteDeadline(time.Now().Add(network.TaskPayloadReadTimeout)); err != nil {
+		http.Error(w, "Failed to set write deadline", http.StatusInternalServerError)
+		return
+	}
 
 	taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s", "task_id": "%s"}`, version.AppVersion, req.Prompt, req.TaskID)
-	_, err = s.Write([]byte(taskJSON))
-	if err != nil {
+	if _, err := s.Write([]byte(taskJSON)); err != nil {
 		http.Error(w, "Failed to send prompt", http.StatusInternalServerError)
 		return
 	}
-	s.CloseWrite()
+	if err := s.CloseWrite(); err != nil {
+		http.Error(w, "Failed to half-close task stream", http.StatusInternalServerError)
+		return
+	}
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -219,9 +234,18 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 	buf := make([]byte, 1024) // Read in small 1KB chunks
 
 	for {
+		// Idle deadline: each read gets up to TaskExecutionTimeout. A task that
+		// never produces output within that window is treated as ghosted.
+		if err := s.SetReadDeadline(time.Now().Add(network.TaskExecutionTimeout)); err != nil {
+			pterm.Error.Printfln("Failed to refresh read deadline: %v", err)
+			return
+		}
 		n, err := s.Read(buf)
 		if n > 0 {
-			w.Write(buf[:n])
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				pterm.Error.Printfln("HTTP client disconnected: %v", werr)
+				return
+			}
 			if flusherSupported {
 				flusher.Flush()
 			}
@@ -229,11 +253,13 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			if err != io.EOF {
 				pterm.Error.Printfln("Stream error: %v", err)
+				return
 			}
 			break
 		}
 	}
 
+	streamSuccess = true
 	pterm.Success.Println("✅ API Task Complete. Text streamed to client.")
 }
 
@@ -280,14 +306,39 @@ func (b *Boss) handleAsyncExecuteTask(w http.ResponseWriter, r *http.Request) {
 		if s == nil {
 			return
 		}
-		defer s.Close()
+
+		streamSuccess := false
+		defer func() {
+			if streamSuccess {
+				_ = s.Close()
+			} else {
+				_ = s.Reset()
+			}
+		}()
+
+		if err := s.SetWriteDeadline(time.Now().Add(network.TaskPayloadReadTimeout)); err != nil {
+			pterm.Error.Printfln("Async task: failed to set write deadline: %v", err)
+			return
+		}
 
 		taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s", "task_id": "%s"}`, version.AppVersion, req.Prompt, taskID)
-		s.Write([]byte(taskJSON))
-		s.CloseWrite()
+		if _, err := s.Write([]byte(taskJSON)); err != nil {
+			pterm.Error.Printfln("Async task: failed to send prompt: %v", err)
+			return
+		}
+		if err := s.CloseWrite(); err != nil {
+			pterm.Error.Printfln("Async task: failed to half-close: %v", err)
+			return
+		}
 
+		deadman := &timeoutReader{stream: s, timeout: network.TaskExecutionTimeout}
 		var outputBuffer bytes.Buffer
-		io.Copy(&outputBuffer, s)
+		if _, err := io.Copy(&outputBuffer, deadman); err != nil {
+			pterm.Error.Printfln("Async task: stream read failed: %v", err)
+			return
+		}
+
+		streamSuccess = true
 
 		time.Sleep(2 * time.Second)
 

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"agentfm/internal/network"
+	"agentfm/internal/types"
 	"agentfm/internal/version"
 
 	netcore "github.com/libp2p/go-libp2p/core/network"
@@ -215,8 +216,13 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s", "task_id": "%s"}`, version.AppVersion, req.Prompt, req.TaskID)
-	if _, err := s.Write([]byte(taskJSON)); err != nil {
+	payload := types.TaskPayload{
+		Version: version.AppVersion,
+		Task:    "agent_task",
+		Data:    req.Prompt,
+		TaskID:  req.TaskID,
+	}
+	if err := json.NewEncoder(s).Encode(&payload); err != nil {
 		http.Error(w, "Failed to send prompt", http.StatusInternalServerError)
 		return
 	}
@@ -321,8 +327,13 @@ func (b *Boss) handleAsyncExecuteTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s", "task_id": "%s"}`, version.AppVersion, req.Prompt, taskID)
-		if _, err := s.Write([]byte(taskJSON)); err != nil {
+		payload := types.TaskPayload{
+			Version: version.AppVersion,
+			Task:    "agent_task",
+			Data:    req.Prompt,
+			TaskID:  taskID,
+		}
+		if err := json.NewEncoder(s).Encode(&payload); err != nil {
 			pterm.Error.Printfln("Async task: failed to send prompt: %v", err)
 			return
 		}

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -179,9 +179,9 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 		req.TaskID = fmt.Sprintf("task_%d", time.Now().UnixNano())
 	}
 
-	b.mu.Lock()
+	b.mu.RLock()
 	_, exists := b.activeWorkers[req.WorkerID]
-	b.mu.Unlock()
+	b.mu.RUnlock()
 
 	if !exists {
 		http.Error(w, "Worker not found or offline", http.StatusNotFound)
@@ -282,9 +282,9 @@ func (b *Boss) handleAsyncExecuteTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b.mu.Lock()
+	b.mu.RLock()
 	_, exists := b.activeWorkers[req.WorkerID]
-	b.mu.Unlock()
+	b.mu.RUnlock()
 
 	if !exists {
 		http.Error(w, "Worker not found or offline", http.StatusNotFound)

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -36,6 +36,26 @@ type AsyncExecuteRequest struct {
 	WebhookURL string `json:"webhook_url"`
 }
 
+// apiWorker is the response DTO for GET /api/workers. It flattens a
+// WorkerProfile into the fields the SDK/UI consumes and renames a few
+// (PeerID vs peer_id is identical; AgentName becomes name, etc.).
+type apiWorker struct {
+	PeerID       string  `json:"peer_id"`
+	Author       string  `json:"author"`
+	Name         string  `json:"name"`
+	Status       string  `json:"status"`
+	Hardware     string  `json:"hardware"`
+	Description  string  `json:"description"`
+	CPUUsagePct  float64 `json:"cpu_usage_pct"`
+	RAMFreeGB    float64 `json:"ram_free_gb"`
+	CurrentTasks int     `json:"current_tasks"`
+	MaxTasks     int     `json:"max_tasks"`
+	HasGPU       bool    `json:"has_gpu"`
+	GPUUsedGB    float64 `json:"gpu_used_gb"`
+	GPUTotalGB   float64 `json:"gpu_total_gb"`
+	GPUUsagePct  float64 `json:"gpu_usage_pct"`
+}
+
 // corsMiddleware wraps standard handlers to easily attach headers
 func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -75,6 +95,18 @@ func (b *Boss) StartAPIServer(port string) {
 	srv := &http.Server{
 		Addr:    ":" + port,
 		Handler: mux,
+		// Defensive server timeouts so slow-loris clients cannot exhaust
+		// handler goroutines.
+		// - ReadHeaderTimeout specifically guards against slow header writes
+		//   (the classic slow-loris vector).
+		// - ReadTimeout bounds the whole request body (small JSON).
+		// - WriteTimeout must be larger than TaskExecutionTimeout because
+		//   /api/execute streams worker stdout for the full task window.
+		// - IdleTimeout reaps dormant keep-alive connections.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      network.TaskExecutionTimeout + 2*time.Minute,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	// Run server in a background goroutine
@@ -124,24 +156,7 @@ func (b *Boss) handleGetWorkers(w http.ResponseWriter, r *http.Request) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	type APIWorker struct {
-		PeerID       string  `json:"peer_id"`
-		Author       string  `json:"author"`
-		Name         string  `json:"name"`
-		Status       string  `json:"status"`
-		Hardware     string  `json:"hardware"`
-		Description  string  `json:"description"`
-		CPUUsagePct  float64 `json:"cpu_usage_pct"`
-		RAMFreeGB    float64 `json:"ram_free_gb"`
-		CurrentTasks int     `json:"current_tasks"`
-		MaxTasks     int     `json:"max_tasks"`
-		HasGPU       bool    `json:"has_gpu"`
-		GPUUsedGB    float64 `json:"gpu_used_gb"`
-		GPUTotalGB   float64 `json:"gpu_total_gb"`
-		GPUUsagePct  float64 `json:"gpu_usage_pct"`
-	}
-
-	agents := make([]APIWorker, 0)
+	agents := make([]apiWorker, 0, len(b.activeWorkers))
 
 	for peerIDStr, profile := range b.activeWorkers {
 
@@ -158,7 +173,7 @@ func (b *Boss) handleGetWorkers(w http.ResponseWriter, r *http.Request) {
 			hardwareStr = fmt.Sprintf("%s (GPU VRAM: %.1f/%.1f GB)", profile.Model, profile.GPUUsedGB, profile.GPUTotalGB)
 		}
 
-		agents = append(agents, APIWorker{
+		agents = append(agents, apiWorker{
 			PeerID:       profile.PeerID,
 			Author:       profile.Author,
 			Name:         profile.AgentName,

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -72,7 +72,7 @@ func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-func (b *Boss) StartAPIServer(port string) {
+func (b *Boss) StartAPIServer(port string) error {
 	// Root ctx cancels on SIGINT/SIGTERM so every downstream goroutine
 	// (telemetry listener, async task workers, webhook POSTs) observes
 	// the same shutdown signal.
@@ -109,17 +109,31 @@ func (b *Boss) StartAPIServer(port string) {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	// Run server in a background goroutine
+	// Run the server in a background goroutine and route its terminal
+	// error through a channel instead of calling pterm.Fatal (which
+	// would os.Exit(1) from inside a goroutine, skipping every defer
+	// in StartAPIServer). A caller-observable return value lets
+	// main.go decide the exit code.
+	serverErrCh := make(chan error, 1)
 	go func() {
 		pterm.Success.Printfln("🚀 AgentFM Local API Gateway listening on http://127.0.0.1:%s", port)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			pterm.Fatal.Printfln("❌ API Server failed: %v", err)
-		}
+		serverErrCh <- srv.ListenAndServe()
 	}()
 
-	<-ctx.Done()
-
-	pterm.Warning.Println("\nShutting down API Gateway gracefully...")
+	var listenErr error
+	select {
+	case <-ctx.Done():
+		pterm.Warning.Println("\nShutting down API Gateway gracefully...")
+	case err := <-serverErrCh:
+		// Server exited before a shutdown signal — typically a bind
+		// failure at startup. Fall through to the drain path so
+		// telemetry/async goroutines still get cleaned up, then
+		// propagate the error to main.
+		if err != nil && err != http.ErrServerClosed {
+			pterm.Error.Printfln("API Server failed: %v", err)
+			listenErr = err
+		}
+	}
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
@@ -145,6 +159,7 @@ func (b *Boss) StartAPIServer(port string) {
 	}
 
 	pterm.Success.Println("API Gateway offline.")
+	return listenErr
 }
 
 func (b *Boss) handleGetWorkers(w http.ResponseWriter, r *http.Request) {

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -212,7 +212,9 @@ func (b *Boss) handleGetWorkers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		pterm.Error.Printfln("Failed to encode /api/workers response: %v", err)
+	}
 }
 
 func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {

--- a/agentfm-go/internal/boss/api.go
+++ b/agentfm-go/internal/boss/api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -20,6 +21,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pterm/pterm"
 )
+
+const webhookTimeout = 30 * time.Second
 
 type ExecuteRequest struct {
 	WorkerID string `json:"worker_id"`
@@ -50,8 +53,16 @@ func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 }
 
 func (b *Boss) StartAPIServer(port string) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Root ctx cancels on SIGINT/SIGTERM so every downstream goroutine
+	// (telemetry listener, async task workers, webhook POSTs) observes
+	// the same shutdown signal.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Tracks in-flight async task goroutines spawned by /api/execute/async.
+	// http.Server.Shutdown only drains HTTP handlers; these goroutines
+	// outlive the handler return, so we drain them explicitly below.
+	var asyncWG sync.WaitGroup
 
 	b.node.Host.SetStreamHandler(network.ArtifactProtocol, network.HandleArtifactStream)
 	go b.listenTelemetry(ctx)
@@ -59,7 +70,7 @@ func (b *Boss) StartAPIServer(port string) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/workers", corsMiddleware(b.handleGetWorkers))
 	mux.HandleFunc("/api/execute", corsMiddleware(b.handleExecuteTask))
-	mux.HandleFunc("/api/execute/async", corsMiddleware(b.handleAsyncExecuteTask))
+	mux.HandleFunc("/api/execute/async", corsMiddleware(b.asyncExecuteHandler(ctx, &asyncWG)))
 
 	srv := &http.Server{
 		Addr:    ":" + port,
@@ -74,10 +85,7 @@ func (b *Boss) StartAPIServer(port string) {
 		}
 	}()
 
-	// Handle graceful shutdown
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	<-ctx.Done()
 
 	pterm.Warning.Println("\nShutting down API Gateway gracefully...")
 
@@ -88,8 +96,23 @@ func (b *Boss) StartAPIServer(port string) {
 		pterm.Error.Printfln("Server forced to shutdown: %v", err)
 	}
 
+	// Wait for async task goroutines to finish, bounded so a hung webhook
+	// cannot block shutdown forever.
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer drainCancel()
+	drained := make(chan struct{})
+	go func() {
+		asyncWG.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		pterm.Success.Println("Async tasks drained.")
+	case <-drainCtx.Done():
+		pterm.Warning.Println("Drain deadline hit — some async tasks still in flight.")
+	}
+
 	pterm.Success.Println("API Gateway offline.")
-	os.Exit(0)
 }
 
 func (b *Boss) handleGetWorkers(w http.ResponseWriter, r *http.Request) {
@@ -269,101 +292,155 @@ func (b *Boss) handleExecuteTask(w http.ResponseWriter, r *http.Request) {
 	pterm.Success.Println("✅ API Task Complete. Text streamed to client.")
 }
 
-func (b *Boss) handleAsyncExecuteTask(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	var req AsyncExecuteRequest
-	limitedReader := io.LimitReader(r.Body, 1*1024*1024)
-	if err := json.NewDecoder(limitedReader).Decode(&req); err != nil {
-		http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
-		return
-	}
-
-	b.mu.RLock()
-	_, exists := b.activeWorkers[req.WorkerID]
-	b.mu.RUnlock()
-
-	if !exists {
-		http.Error(w, "Worker not found or offline", http.StatusNotFound)
-		return
-	}
-
-	peerID, err := peer.Decode(req.WorkerID)
-	if err != nil {
-		http.Error(w, "Invalid Worker ID format", http.StatusBadRequest)
-		return
-	}
-
-	taskID := fmt.Sprintf("task_%d", time.Now().UnixNano())
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	json.NewEncoder(w).Encode(map[string]string{
-		"task_id": taskID,
-		"status":  "queued",
-		"message": "Task dispatched to P2P mesh.",
-	})
-
-	go func() {
-		s := b.dialOmni(peerID)
-		if s == nil {
+// asyncExecuteHandler returns the /api/execute/async handler wired to the
+// server-lifetime rootCtx and an inflight WaitGroup. The handler spawns a
+// background goroutine after responding 202; that goroutine inherits rootCtx
+// (so SIGINT cancels it) and calls wg.Done() on exit so StartAPIServer can
+// wait for an orderly drain.
+func (b *Boss) asyncExecuteHandler(rootCtx context.Context, wg *sync.WaitGroup) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		streamSuccess := false
-		defer func() {
-			if streamSuccess {
-				_ = s.Close()
-			} else {
-				_ = s.Reset()
-			}
+		var req AsyncExecuteRequest
+		limitedReader := io.LimitReader(r.Body, 1*1024*1024)
+		if err := json.NewDecoder(limitedReader).Decode(&req); err != nil {
+			http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
+			return
+		}
+
+		b.mu.RLock()
+		_, exists := b.activeWorkers[req.WorkerID]
+		b.mu.RUnlock()
+
+		if !exists {
+			http.Error(w, "Worker not found or offline", http.StatusNotFound)
+			return
+		}
+
+		peerID, err := peer.Decode(req.WorkerID)
+		if err != nil {
+			http.Error(w, "Invalid Worker ID format", http.StatusBadRequest)
+			return
+		}
+
+		taskID := fmt.Sprintf("task_%d", time.Now().UnixNano())
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"task_id": taskID,
+			"status":  "queued",
+			"message": "Task dispatched to P2P mesh.",
+		}); err != nil {
+			pterm.Error.Printfln("Async task: failed to write ack: %v", err)
+			return
+		}
+
+		// Budget the whole background job (stream + webhook) by the task
+		// execution timeout so a ghosted worker can't hold a goroutine
+		// past server shutdown.
+		taskCtx, cancelTask := context.WithTimeout(rootCtx, network.TaskExecutionTimeout)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer cancelTask()
+
+			b.runAsyncTask(taskCtx, peerID, taskID, req)
 		}()
+	}
+}
 
-		if err := s.SetWriteDeadline(time.Now().Add(network.TaskPayloadReadTimeout)); err != nil {
-			pterm.Error.Printfln("Async task: failed to set write deadline: %v", err)
-			return
-		}
+func (b *Boss) runAsyncTask(ctx context.Context, peerID peer.ID, taskID string, req AsyncExecuteRequest) {
+	s := b.dialOmni(peerID)
+	if s == nil {
+		return
+	}
 
-		payload := types.TaskPayload{
-			Version: version.AppVersion,
-			Task:    "agent_task",
-			Data:    req.Prompt,
-			TaskID:  taskID,
-		}
-		if err := json.NewEncoder(s).Encode(&payload); err != nil {
-			pterm.Error.Printfln("Async task: failed to send prompt: %v", err)
-			return
-		}
-		if err := s.CloseWrite(); err != nil {
-			pterm.Error.Printfln("Async task: failed to half-close: %v", err)
-			return
-		}
-
-		deadman := &timeoutReader{stream: s, timeout: network.TaskExecutionTimeout}
-		var outputBuffer bytes.Buffer
-		if _, err := io.Copy(&outputBuffer, deadman); err != nil {
-			pterm.Error.Printfln("Async task: stream read failed: %v", err)
-			return
-		}
-
-		streamSuccess = true
-
-		time.Sleep(2 * time.Second)
-
-		if req.WebhookURL != "" {
-			webhookPayload := map[string]string{
-				"task_id":   taskID,
-				"worker_id": req.WorkerID,
-				"status":    "completed",
-			}
-			jsonData, _ := json.Marshal(webhookPayload)
-			resp, err := http.Post(req.WebhookURL, "application/json", bytes.NewBuffer(jsonData))
-			if err == nil {
-				resp.Body.Close()
-			}
+	streamSuccess := false
+	defer func() {
+		if streamSuccess {
+			_ = s.Close()
+		} else {
+			_ = s.Reset()
 		}
 	}()
+
+	if err := s.SetWriteDeadline(time.Now().Add(network.TaskPayloadReadTimeout)); err != nil {
+		pterm.Error.Printfln("Async task: failed to set write deadline: %v", err)
+		return
+	}
+
+	payload := types.TaskPayload{
+		Version: version.AppVersion,
+		Task:    "agent_task",
+		Data:    req.Prompt,
+		TaskID:  taskID,
+	}
+	if err := json.NewEncoder(s).Encode(&payload); err != nil {
+		pterm.Error.Printfln("Async task: failed to send prompt: %v", err)
+		return
+	}
+	if err := s.CloseWrite(); err != nil {
+		pterm.Error.Printfln("Async task: failed to half-close: %v", err)
+		return
+	}
+
+	deadman := &timeoutReader{stream: s, timeout: network.TaskExecutionTimeout}
+	var outputBuffer bytes.Buffer
+	if _, err := io.Copy(&outputBuffer, deadman); err != nil {
+		pterm.Error.Printfln("Async task: stream read failed: %v", err)
+		return
+	}
+
+	streamSuccess = true
+
+	// Brief grace period so the out-of-band artifact stream (handled by
+	// HandleArtifactStream on a separate libp2p stream) lands on disk
+	// before we notify the webhook. Aborted early if the server is
+	// shutting down.
+	select {
+	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
+		return
+	}
+
+	if req.WebhookURL == "" {
+		return
+	}
+
+	webhookPayload := map[string]string{
+		"task_id":   taskID,
+		"worker_id": req.WorkerID,
+		"status":    "completed",
+	}
+	jsonData, err := json.Marshal(webhookPayload)
+	if err != nil {
+		pterm.Error.Printfln("Async task: failed to marshal webhook payload: %v", err)
+		return
+	}
+
+	// Bounded webhook POST. The default http.Client has NO timeout, so a
+	// hostile or slow webhook URL would otherwise stall this goroutine —
+	// and therefore the server drain — indefinitely.
+	webhookCtx, webhookCancel := context.WithTimeout(ctx, webhookTimeout)
+	defer webhookCancel()
+
+	httpReq, err := http.NewRequestWithContext(webhookCtx, http.MethodPost, req.WebhookURL, bytes.NewReader(jsonData))
+	if err != nil {
+		pterm.Error.Printfln("Async task: failed to build webhook request: %v", err)
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: webhookTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		pterm.Error.Printfln("Async task: webhook delivery failed: %v", err)
+		return
+	}
+	_ = resp.Body.Close()
 }

--- a/agentfm-go/internal/boss/boss.go
+++ b/agentfm-go/internal/boss/boss.go
@@ -19,7 +19,11 @@ type Boss struct {
 	node          *network.MeshNode
 	activeWorkers map[string]types.WorkerProfile
 	lastSeen      map[string]time.Time
-	mu            sync.Mutex
+	// RWMutex because the activeWorkers/lastSeen maps are read heavily
+	// (HTTP /api/workers, /api/execute, /api/execute/async, the TUI redraw
+	// ticker) but written only when a telemetry pulse arrives. Pure-read
+	// call sites use RLock so concurrent API hits don't serialise.
+	mu sync.RWMutex
 }
 
 func New(node *network.MeshNode) *Boss {

--- a/agentfm-go/internal/boss/boss.go
+++ b/agentfm-go/internal/boss/boss.go
@@ -3,6 +3,7 @@ package boss
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -41,11 +42,19 @@ func (b *Boss) Run(ctx context.Context) {
 	go b.listenTelemetry(ctx)
 
 	for {
-		worker, ok := b.selectWorkerInteractive()
+		worker, ok, quit := b.selectWorkerInteractive(ctx)
+		if quit || ctx.Err() != nil {
+			break
+		}
 		if !ok {
 			continue
 		}
 		b.executeFlow(worker)
+	}
+
+	fmt.Println("\nShutting down Boss node...")
+	if err := b.node.Host.Close(); err != nil {
+		pterm.Error.Printfln("Host close error: %v", err)
 	}
 }
 

--- a/agentfm-go/internal/boss/boss.go
+++ b/agentfm-go/internal/boss/boss.go
@@ -52,12 +52,18 @@ func (b *Boss) Run(ctx context.Context) {
 func (b *Boss) listenTelemetry(ctx context.Context) {
 	topic, err := b.node.PubSub.Join(network.TelemetryTopic)
 	if err != nil {
-		pterm.Fatal.Println(err)
+		// Non-fatal: surface the error and return so the caller's
+		// defers still run. Boss keeps working for manually-specified
+		// peers but the radar will be empty.
+		pterm.Error.Printfln("Telemetry listener disabled: failed to join %q: %v", network.TelemetryTopic, err)
+		return
 	}
 	sub, err := topic.Subscribe()
 	if err != nil {
-		pterm.Fatal.Println(err)
+		pterm.Error.Printfln("Telemetry listener disabled: failed to subscribe: %v", err)
+		return
 	}
+	defer sub.Cancel()
 
 	for {
 		msg, err := sub.Next(ctx)

--- a/agentfm-go/internal/boss/boss.go
+++ b/agentfm-go/internal/boss/boss.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pterm/pterm"
 )
 
-const AppVersion = "1.0.0"
-
 type Boss struct {
 	node          *network.MeshNode
 	activeWorkers map[string]types.WorkerProfile

--- a/agentfm-go/internal/boss/execute.go
+++ b/agentfm-go/internal/boss/execute.go
@@ -63,8 +63,12 @@ func (b *Boss) executeFlow(worker types.WorkerProfile) {
 		return
 	}
 
-	taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s"}`, version.AppVersion, prompt)
-	if _, err := s.Write([]byte(taskJSON)); err != nil {
+	payload := types.TaskPayload{
+		Version: version.AppVersion,
+		Task:    "agent_task",
+		Data:    prompt,
+	}
+	if err := json.NewEncoder(s).Encode(&payload); err != nil {
 		pterm.Error.Printfln("Failed to send prompt: %v", err)
 		return
 	}

--- a/agentfm-go/internal/boss/execute.go
+++ b/agentfm-go/internal/boss/execute.go
@@ -36,7 +36,11 @@ func (b *Boss) executeFlow(worker types.WorkerProfile) {
 		return
 	}
 
-	targetPeerID, _ := peer.Decode(worker.PeerID)
+	targetPeerID, err := peer.Decode(worker.PeerID)
+	if err != nil {
+		pterm.Error.Printfln("Invalid worker peer ID %q: %v", worker.PeerID, err)
+		return
+	}
 	fmt.Println()
 	pterm.Info.Printfln("Initiating secure encrypted TCP tunnel to %s...", pterm.Cyan(targetPeerID.String()[:8]))
 
@@ -45,20 +49,43 @@ func (b *Boss) executeFlow(worker types.WorkerProfile) {
 		return
 	}
 
+	streamSuccess := false
+	defer func() {
+		if streamSuccess {
+			_ = s.Close()
+		} else {
+			_ = s.Reset()
+		}
+	}()
+
+	if err := s.SetWriteDeadline(time.Now().Add(network.TaskPayloadReadTimeout)); err != nil {
+		pterm.Error.Printfln("Failed to set write deadline: %v", err)
+		return
+	}
+
 	taskJSON := fmt.Sprintf(`{"version": "%s", "task": "agent_task", "data": "%s"}`, version.AppVersion, prompt)
-	s.Write([]byte(taskJSON))
-	s.CloseWrite()
+	if _, err := s.Write([]byte(taskJSON)); err != nil {
+		pterm.Error.Printfln("Failed to send prompt: %v", err)
+		return
+	}
+	if err := s.CloseWrite(); err != nil {
+		pterm.Error.Printfln("Failed to half-close tunnel: %v", err)
+		return
+	}
 
 	pterm.DefaultSection.WithLevel(2).Println("🤖 LIVE AGENT STREAM")
 
-	deadman := &timeoutReader{stream: s, timeout: 10 * time.Minute}
+	deadman := &timeoutReader{stream: s, timeout: network.TaskExecutionTimeout}
 	if _, err := io.Copy(os.Stdout, deadman); err != nil {
 		if os.IsTimeout(err) {
-			pterm.Error.Println("\n⏳ WORKER GHOSTED: Stream timed out after 10 minutes.")
+			pterm.Error.Println("\n⏳ WORKER GHOSTED: Stream timed out.")
 		} else {
 			pterm.Error.Printfln("\n💥 Stream broken: %v", err)
 		}
+		return
 	}
+
+	streamSuccess = true
 
 	fmt.Println()
 	pterm.DefaultSection.WithLevel(2).Println("END OF STREAM")
@@ -101,7 +128,9 @@ func (b *Boss) dialOmni(target peer.ID) netcore.Stream {
 
 	spinner.UpdateText("Dialing peer directly and via Hetzner Relay simultaneously...")
 
-	s, err := b.node.Host.NewStream(context.Background(), target, network.TaskProtocol)
+	dialCtx, cancel := context.WithTimeout(context.Background(), network.StreamDialTimeout)
+	defer cancel()
+	s, err := b.node.Host.NewStream(dialCtx, target, network.TaskProtocol)
 	if err != nil {
 		spinner.Fail(fmt.Sprintf("Failed to connect via Direct IP or Relay: %v", err))
 		time.Sleep(3 * time.Second)
@@ -115,19 +144,45 @@ func (b *Boss) dialOmni(target peer.ID) netcore.Stream {
 func (b *Boss) handleFeedbackLoop(target peer.ID) {
 	fmt.Println()
 	leave, _ := pterm.DefaultInteractiveConfirm.WithDefaultValue(false).Show("📝 Leave feedback for the node operator?")
-	if leave {
-		feedback, _ := pterm.DefaultInteractiveTextInput.Show("Type your feedback")
-		if strings.TrimSpace(feedback) != "" {
-			pterm.Info.Println("Opening secure feedback tunnel...")
-
-			if fs, err := b.node.Host.NewStream(context.Background(), target, network.FeedbackProtocol); err == nil {
-				payload := map[string]string{"feedback": feedback, "timestamp": time.Now().Format(time.RFC3339)}
-				json.NewEncoder(fs).Encode(payload)
-				fs.Close()
-				pterm.Success.Println("Feedback delivered directly to the worker! 💌")
-			} else {
-				pterm.Error.Printfln("Failed to deliver feedback: %v", err)
-			}
-		}
+	if !leave {
+		return
 	}
+	feedback, _ := pterm.DefaultInteractiveTextInput.Show("Type your feedback")
+	if strings.TrimSpace(feedback) == "" {
+		return
+	}
+
+	pterm.Info.Println("Opening secure feedback tunnel...")
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), network.StreamDialTimeout)
+	defer cancel()
+
+	fs, err := b.node.Host.NewStream(dialCtx, target, network.FeedbackProtocol)
+	if err != nil {
+		pterm.Error.Printfln("Failed to deliver feedback: %v", err)
+		return
+	}
+
+	reset := true
+	defer func() {
+		if reset {
+			_ = fs.Reset()
+		} else {
+			_ = fs.Close()
+		}
+	}()
+
+	if err := fs.SetWriteDeadline(time.Now().Add(network.FeedbackStreamTimeout)); err != nil {
+		pterm.Error.Printfln("Failed to set feedback deadline: %v", err)
+		return
+	}
+
+	payload := map[string]string{"feedback": feedback, "timestamp": time.Now().Format(time.RFC3339)}
+	if err := json.NewEncoder(fs).Encode(payload); err != nil {
+		pterm.Error.Printfln("Failed to deliver feedback: %v", err)
+		return
+	}
+
+	reset = false
+	pterm.Success.Println("Feedback delivered directly to the worker! 💌")
 }

--- a/agentfm-go/internal/boss/ui.go
+++ b/agentfm-go/internal/boss/ui.go
@@ -3,7 +3,6 @@ package boss
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,8 +36,14 @@ func renderCPUBar(percent float64) string {
 	return pterm.Green(fmt.Sprintf("[%s] %5.1f%%", bar, percent))
 }
 
-func (b *Boss) selectWorkerInteractive() (types.WorkerProfile, bool) {
-	uiCtx, cancelUI := context.WithCancel(context.Background())
+// selectWorkerInteractive blocks on keyboard input and returns
+// (selected, confirmed, quit). `quit=true` means the user pressed Ctrl+C
+// and Boss.Run should break out of its loop and shut down cleanly — we
+// don't call os.Exit from the key callback because that skips every
+// pending defer (cancelUI, area.Stop) and can leave the terminal in a
+// bad state on some setups.
+func (b *Boss) selectWorkerInteractive(parentCtx context.Context) (types.WorkerProfile, bool, bool) {
+	uiCtx, cancelUI := context.WithCancel(parentCtx)
 	defer cancelUI()
 
 	selectedIndex := 0
@@ -162,15 +167,12 @@ func (b *Boss) selectWorkerInteractive() (types.WorkerProfile, bool) {
 	draw()
 
 	var selected types.WorkerProfile
-	var confirmed bool
+	var confirmed, quit bool
 
 	keyboard.Listen(func(key keys.Key) (stop bool, err error) {
 		if key.Code == keys.CtrlC {
-			b.mu.Lock()
-			fmt.Println("\nShutting down Boss node...")
-			b.node.Host.Close()
-			b.mu.Unlock()
-			os.Exit(0)
+			quit = true
+			return true, nil
 		}
 
 		// Use a local copy of length to prevent data races
@@ -196,5 +198,5 @@ func (b *Boss) selectWorkerInteractive() (types.WorkerProfile, bool) {
 		}
 		return false, nil
 	})
-	return selected, confirmed
+	return selected, confirmed, quit
 }

--- a/agentfm-go/internal/network/artifacts.go
+++ b/agentfm-go/internal/network/artifacts.go
@@ -18,11 +18,26 @@ import (
 func SendArtifacts(ctx context.Context, h host.Host, bossID peer.ID, zipFilePath string, taskID string) error {
 	fmt.Println("📦 Opening secure artifact channel to Boss...")
 
-	stream, err := h.NewStream(ctx, bossID, ArtifactProtocol)
+	dialCtx, cancel := context.WithTimeout(ctx, StreamDialTimeout)
+	defer cancel()
+
+	stream, err := h.NewStream(dialCtx, bossID, ArtifactProtocol)
 	if err != nil {
 		return fmt.Errorf("failed to open artifact stream: %w", err)
 	}
-	defer stream.Close()
+
+	success := false
+	defer func() {
+		if success {
+			_ = stream.Close()
+		} else {
+			_ = stream.Reset()
+		}
+	}()
+
+	if err := stream.SetWriteDeadline(time.Now().Add(ArtifactStreamTimeout)); err != nil {
+		return fmt.Errorf("failed to set artifact write deadline: %w", err)
+	}
 
 	file, err := os.Open(zipFilePath)
 	if err != nil {
@@ -35,20 +50,17 @@ func SendArtifacts(ctx context.Context, h host.Host, bossID peer.ID, zipFilePath
 		return fmt.Errorf("failed to stat file: %w", err)
 	}
 
-	err = binary.Write(stream, binary.LittleEndian, stat.Size())
-	if err != nil {
-		return err
+	if err := binary.Write(stream, binary.LittleEndian, stat.Size()); err != nil {
+		return fmt.Errorf("failed to write size header: %w", err)
 	}
 
 	taskIDBytes := []byte(taskID)
-	err = binary.Write(stream, binary.LittleEndian, uint8(len(taskIDBytes)))
-	if err != nil {
-		return err
+	if err := binary.Write(stream, binary.LittleEndian, uint8(len(taskIDBytes))); err != nil {
+		return fmt.Errorf("failed to write task id length: %w", err)
 	}
 
-	_, err = stream.Write(taskIDBytes)
-	if err != nil {
-		return err
+	if _, err := stream.Write(taskIDBytes); err != nil {
+		return fmt.Errorf("failed to write task id: %w", err)
 	}
 
 	bytesWritten, err := io.Copy(stream, file)
@@ -56,6 +68,7 @@ func SendArtifacts(ctx context.Context, h host.Host, bossID peer.ID, zipFilePath
 		return fmt.Errorf("failed during artifact stream: %w", err)
 	}
 
+	success = true
 	fmt.Printf("✅ Successfully sent %d bytes of artifacts over the darknet!\n", bytesWritten)
 	return nil
 }
@@ -75,7 +88,19 @@ func (pw *progressWriter) Write(p []byte) (n int, err error) {
 }
 
 func HandleArtifactStream(stream network.Stream) {
-	defer stream.Close()
+	success := false
+	defer func() {
+		if success {
+			_ = stream.Close()
+		} else {
+			_ = stream.Reset()
+		}
+	}()
+
+	if err := stream.SetReadDeadline(time.Now().Add(ArtifactStreamTimeout)); err != nil {
+		pterm.Error.Printfln("Failed to set artifact read deadline: %v", err)
+		return
+	}
 
 	fmt.Println("\n📥 [INCOMING] Artifact stream detected from Worker!")
 
@@ -106,7 +131,10 @@ func HandleArtifactStream(stream network.Stream) {
 		safeTaskID = fmt.Sprintf("fallback_%d", time.Now().UnixNano())
 	}
 
-	os.MkdirAll("./agentfm_artifacts", 0755)
+	if err := os.MkdirAll("./agentfm_artifacts", 0755); err != nil {
+		pterm.Error.Printfln("Failed to create artifacts dir: %v", err)
+		return
+	}
 	destPath := filepath.Join(".", "agentfm_artifacts", safeTaskID+".zip")
 
 	outFile, err := os.Create(destPath)
@@ -116,9 +144,13 @@ func HandleArtifactStream(stream network.Stream) {
 	}
 	defer outFile.Close()
 
+	progressTitle := safeTaskID
+	if len(progressTitle) > 8 {
+		progressTitle = progressTitle[:8]
+	}
 	pb, _ := pterm.DefaultProgressbar.
 		WithTotal(int(fileSize)).
-		WithTitle(fmt.Sprintf("Downloading %s.zip", safeTaskID[:8])).
+		WithTitle(fmt.Sprintf("Downloading %s.zip", progressTitle)).
 		Start()
 
 	pw := &progressWriter{
@@ -133,6 +165,7 @@ func HandleArtifactStream(stream network.Stream) {
 		return
 	}
 	pb.Stop()
+	success = true
 	pterm.Success.Printfln("🎉 Transfer Complete! Securely saved %d bytes to %s", bytesRead, destPath)
 	fmt.Println()
 	pterm.Println(pterm.LightWhite("👉 Press [ENTER] to continue to the feedback menu."))

--- a/agentfm-go/internal/network/artifacts.go
+++ b/agentfm-go/internal/network/artifacts.go
@@ -79,7 +79,6 @@ type progressWriter struct {
 }
 
 func (pw *progressWriter) Write(p []byte) (n int, err error) {
-	time.Sleep(2 * time.Millisecond)
 	n, err = pw.Writer.Write(p)
 	if n > 0 && pw.pb != nil {
 		pw.pb.Add(n)

--- a/agentfm-go/internal/network/p2p.go
+++ b/agentfm-go/internal/network/p2p.go
@@ -105,7 +105,12 @@ func loadOrGenerateIdentity(mode string) (crypto.PrivKey, error) {
 }
 
 func createHost(cfg Config, bootstrapAddr string) (host.Host, error) {
-	listenAddr := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.ListenPort)
+	// Listen on both v4 and v6 to match the relay binary's dual-stack
+	// config. A v6-only home network would otherwise be unreachable.
+	listenAddrs := []string{
+		fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.ListenPort),
+		fmt.Sprintf("/ip6/::/tcp/%d", cfg.ListenPort),
+	}
 
 	privKey, err := loadOrGenerateIdentity(cfg.Mode)
 	if err != nil {
@@ -113,7 +118,7 @@ func createHost(cfg Config, bootstrapAddr string) (host.Host, error) {
 	}
 
 	options := []libp2p.Option{
-		libp2p.ListenAddrStrings(listenAddr),
+		libp2p.ListenAddrStrings(listenAddrs...),
 		libp2p.NATPortMap(),
 		libp2p.Identity(privKey), // Attach permanent identity to libp2p
 	}

--- a/agentfm-go/internal/network/p2p.go
+++ b/agentfm-go/internal/network/p2p.go
@@ -88,11 +88,18 @@ func loadOrGenerateIdentity(mode string) (crypto.PrivKey, error) {
 	fmt.Println("🔑 Generating new permanent node identity...")
 	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("generate identity key: %w", err)
 	}
 
-	keyBytes, _ := crypto.MarshalPrivateKey(priv)
-	os.WriteFile(keyPath, keyBytes, 0600)
+	keyBytes, err := crypto.MarshalPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("marshal identity key: %w", err)
+	}
+	if err := os.WriteFile(keyPath, keyBytes, 0600); err != nil {
+		// Not fatal: the node can still run with an ephemeral key, but the
+		// operator needs to know the peer ID won't be stable across restarts.
+		fmt.Printf("⚠️  Failed to persist identity at %s: %v (peer ID will change on restart)\n", keyPath, err)
+	}
 
 	return priv, nil
 }
@@ -174,12 +181,18 @@ func initRoutingAndPubSub(ctx context.Context, h host.Host, isWorker bool) (*pub
 
 func connectToLighthouse(ctx context.Context, h host.Host, relayInfo *peer.AddrInfo) {
 	fmt.Println("🌍 Dialing Bootstrap Node / Relay...")
-	if err := h.Connect(ctx, *relayInfo); err != nil {
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, StreamDialTimeout)
+	defer dialCancel()
+	if err := h.Connect(dialCtx, *relayInfo); err != nil {
 		fmt.Printf("⚠️  Failed to connect to Bootstrap Node: %v\n", err)
 		return
 	}
 	fmt.Println("✅ Successfully connected to Bootstrap Node!")
-	if _, err := client.Reserve(ctx, h, *relayInfo); err != nil {
+
+	reserveCtx, reserveCancel := context.WithTimeout(ctx, StreamDialTimeout)
+	defer reserveCancel()
+	if _, err := client.Reserve(reserveCtx, h, *relayInfo); err != nil {
 		fmt.Printf("⚠️  Failed to secure relay reservation: %v\n", err)
 	} else {
 		fmt.Println("✅ Relay reservation secured! Ready for NAT traversal fallback.")
@@ -208,20 +221,28 @@ func discoverPeers(ctx context.Context, h host.Host, routingDiscovery *routing.R
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			peerChan, err := routingDiscovery.FindPeers(ctx, RendezvousString)
+			// Each DHT sweep is individually bounded so one unresponsive
+			// peer can't stall the tick beyond the next interval.
+			lookupCtx, lookupCancel := context.WithTimeout(ctx, StreamDialTimeout)
+			peerChan, err := routingDiscovery.FindPeers(lookupCtx, RendezvousString)
 			if err != nil {
+				lookupCancel()
 				continue
 			}
 			for p := range peerChan {
 				if p.ID == h.ID() || len(p.Addrs) == 0 {
 					continue
 				}
-				if h.Network().Connectedness(p.ID) != netcore.Connected {
-					if err := h.Connect(ctx, p); err == nil {
-						fmt.Printf("\n🌍 [DHT Fallback] Successfully connected to peer: %s\n", p.ID.String()[:8])
-					}
+				if h.Network().Connectedness(p.ID) == netcore.Connected {
+					continue
 				}
+				dialCtx, dialCancel := context.WithTimeout(ctx, StreamDialTimeout)
+				if err := h.Connect(dialCtx, p); err == nil {
+					fmt.Printf("\n🌍 [DHT Fallback] Successfully connected to peer: %s\n", p.ID.String()[:8])
+				}
+				dialCancel()
 			}
+			lookupCancel()
 		}
 	}
 }
@@ -230,5 +251,12 @@ type mdnsNotifee struct{ h host.Host }
 
 func (n *mdnsNotifee) HandlePeerFound(pi peer.AddrInfo) {
 	fmt.Printf("\n⚡ [mDNS] Discovered local node on Wi-Fi: %s\n", pi.ID.String()[:8])
-	n.h.Connect(context.Background(), pi)
+	// mdns invokes this callback from its own goroutine with no parent
+	// context, so a fresh bounded ctx is the right escape hatch here —
+	// it caps the dial instead of blocking the mdns service indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), StreamDialTimeout)
+	defer cancel()
+	if err := n.h.Connect(ctx, pi); err != nil {
+		fmt.Printf("⚠️  [mDNS] Failed to dial %s: %v\n", pi.ID.String()[:8], err)
+	}
 }

--- a/agentfm-go/internal/types/types.go
+++ b/agentfm-go/internal/types/types.go
@@ -17,3 +17,13 @@ type WorkerProfile struct {
 	MaxTasks     int     `json:"max_tasks"`
 	Author       string  `json:"author"`
 }
+
+// TaskPayload is the JSON envelope the Boss sends to a Worker over
+// TaskProtocol. Shared between both sides so there is one schema and no
+// hand-rolled JSON formatting in the boss package.
+type TaskPayload struct {
+	Version string `json:"version"`
+	Task    string `json:"task"`
+	Data    string `json:"data"`
+	TaskID  string `json:"task_id"`
+}

--- a/agentfm-go/internal/worker/handler.go
+++ b/agentfm-go/internal/worker/handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"agentfm/internal/network"
 	"agentfm/internal/utils"
@@ -27,7 +28,21 @@ func isDirEmpty(name string) bool {
 }
 
 func (w *Worker) handleTaskStream(s netcore.Stream) {
-	defer s.Close()
+	// Default to Reset on any early/error exit. A caller that reaches the
+	// normal end of the task flips this to a graceful Close.
+	reset := true
+	defer func() {
+		if reset {
+			_ = s.Reset()
+		} else {
+			_ = s.Close()
+		}
+	}()
+
+	// Short deadline for the incoming task JSON. Extended below once the
+	// payload is accepted and we start streaming stdout back.
+	_ = s.SetDeadline(time.Now().Add(network.TaskPayloadReadTimeout))
+
 	fmt.Println()
 	pterm.Info.Println("Incoming P2P task tunnel established...")
 
@@ -37,7 +52,9 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 	if w.currentTasks >= w.config.MaxConcurrentTasks {
 		w.mu.Unlock()
 		pterm.Error.Printfln("Rejected task: Worker is at max capacity (%d/%d).", w.currentTasks, w.config.MaxConcurrentTasks)
-		s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker is at max capacity (%d/%d). Try another worker.\n", w.currentTasks, w.config.MaxConcurrentTasks)))
+		_, _ = s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker is at max capacity (%d/%d). Try another worker.\n", w.currentTasks, w.config.MaxConcurrentTasks)))
+		// App-level rejection delivered — close gracefully so the peer sees the message.
+		reset = false
 		return
 	}
 
@@ -53,14 +70,16 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 
 	if cpuLoad >= w.config.MaxCPU { // Dynamic Threshold
 		pterm.Error.Printfln("Rejected task: Worker CPU is overloaded at %.1f%%.", cpuLoad)
-		s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker is under heavy load (CPU %.1f%%). Try again later.\n", cpuLoad)))
+		_, _ = s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker is under heavy load (CPU %.1f%%). Try again later.\n", cpuLoad)))
+		reset = false
 		return
 	}
 
 	hasGPU, _, _, gpuPct := getGPUStats()
 	if hasGPU && gpuPct > w.config.MaxGPU { // Dynamic Threshold
 		pterm.Error.Printfln("Rejected task: Worker GPU VRAM is busy (%.1f%% used).", gpuPct)
-		s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker GPU is busy (%.1f%% VRAM used). Try another worker.\n", gpuPct)))
+		_, _ = s.Write([]byte(fmt.Sprintf("❌ ERROR: Worker GPU is busy (%.1f%% VRAM used). Try another worker.\n", gpuPct)))
+		reset = false
 		return
 	}
 
@@ -74,14 +93,19 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 	limitedReader := io.LimitReader(s, 1*1024*1024)
 
 	if err := json.NewDecoder(limitedReader).Decode(&payload); err != nil {
+		// Invalid / truncated payload — Reset, per CLAUDE.md §1.1.
 		pterm.Error.Println("Failed to decode incoming task payload (or payload exceeded 1MB limit).")
 		return
 	}
 
 	if payload.Version != version.AppVersion {
-		s.Write([]byte(fmt.Sprintf("❌ ERROR: Version mismatch! Worker is running v%s.\n", version.AppVersion)))
+		_, _ = s.Write([]byte(fmt.Sprintf("❌ ERROR: Version mismatch! Worker is running v%s.\n", version.AppVersion)))
+		reset = false
 		return
 	}
+
+	// Payload accepted. Extend deadline to cover long-running stdout streaming.
+	_ = s.SetDeadline(time.Now().Add(network.TaskExecutionTimeout))
 
 	pterm.Info.Printfln("Executing task %s in Podman sandbox...", payload.TaskID)
 
@@ -89,7 +113,7 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 	defer os.RemoveAll(outputDir)
 
 	if !isDirEmpty(outputDir) {
-		s.Write([]byte("\n[AGENTFM: FILES_INCOMING]\n"))
+		_, _ = s.Write([]byte("\n[AGENTFM: FILES_INCOMING]\n"))
 		pterm.Info.Println("Artifacts detected. Preparing zip...")
 
 		zipPath := outputDir + "_payload.zip"
@@ -97,20 +121,34 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 
 		if err := utils.ZipDirectory(outputDir, zipPath); err == nil {
 			pterm.Info.Println("Routing artifacts to Boss over secure channel...")
-			if sendErr := network.SendArtifacts(context.Background(), w.node.Host, bossID, zipPath, payload.TaskID); sendErr != nil {
+			artifactCtx, cancel := context.WithTimeout(context.Background(), network.ArtifactStreamTimeout)
+			if sendErr := network.SendArtifacts(artifactCtx, w.node.Host, bossID, zipPath, payload.TaskID); sendErr != nil {
 				pterm.Error.Printfln("Failed to route artifacts: %v", sendErr)
 			}
+			cancel()
 		} else {
 			pterm.Error.Printfln("Failed to zip artifacts: %v", err)
 		}
 	} else {
-		s.Write([]byte("\n[AGENTFM: NO_FILES]\n"))
+		_, _ = s.Write([]byte("\n[AGENTFM: NO_FILES]\n"))
 		pterm.Success.Println("No artifacts generated. Task complete.")
 	}
+
+	reset = false
 }
 
 func (w *Worker) handleFeedbackStream(s netcore.Stream) {
-	defer s.Close()
+	reset := true
+	defer func() {
+		if reset {
+			_ = s.Reset()
+		} else {
+			_ = s.Close()
+		}
+	}()
+
+	_ = s.SetDeadline(time.Now().Add(network.FeedbackStreamTimeout))
+
 	var payload struct {
 		Task      string `json:"task"`
 		Feedback  string `json:"feedback"`
@@ -130,4 +168,6 @@ func (w *Worker) handleFeedbackStream(s netcore.Stream) {
 		defer f.Close()
 		f.WriteString(fmt.Sprintf("[%s] Task: %s | Feedback: %s\n", payload.Timestamp, payload.Task, payload.Feedback))
 	}
+
+	reset = false
 }

--- a/agentfm-go/internal/worker/handler.go
+++ b/agentfm-go/internal/worker/handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"agentfm/internal/network"
+	"agentfm/internal/types"
 	"agentfm/internal/utils"
 	"agentfm/internal/version"
 
@@ -83,12 +84,7 @@ func (w *Worker) handleTaskStream(rootCtx context.Context, s netcore.Stream) {
 		return
 	}
 
-	var payload struct {
-		Version string `json:"version"`
-		Task    string `json:"task"`
-		Data    string `json:"data"`
-		TaskID  string `json:"task_id"`
-	}
+	var payload types.TaskPayload
 
 	limitedReader := io.LimitReader(s, 1*1024*1024)
 

--- a/agentfm-go/internal/worker/handler.go
+++ b/agentfm-go/internal/worker/handler.go
@@ -27,7 +27,7 @@ func isDirEmpty(name string) bool {
 	return err != nil
 }
 
-func (w *Worker) handleTaskStream(s netcore.Stream) {
+func (w *Worker) handleTaskStream(rootCtx context.Context, s netcore.Stream) {
 	// Default to Reset on any early/error exit. A caller that reaches the
 	// normal end of the task flips this to a graceful Close.
 	reset := true
@@ -107,9 +107,33 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 	// Payload accepted. Extend deadline to cover long-running stdout streaming.
 	_ = s.SetDeadline(time.Now().Add(network.TaskExecutionTimeout))
 
+	// Task-scoped ctx: cancels on worker shutdown (rootCtx), on
+	// TaskExecutionTimeout, and on remote conn death (watcher below).
+	// Passed to executePodman so exec.CommandContext SIGKILLs the
+	// container the instant the tunnel dies.
+	taskCtx, cancelTask := context.WithTimeout(rootCtx, network.TaskExecutionTimeout)
+	defer cancelTask()
+
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-taskCtx.Done():
+				return
+			case <-ticker.C:
+				if s.Conn().IsClosed() {
+					pterm.Warning.Println("Remote Boss connection died; cancelling sandbox...")
+					cancelTask()
+					return
+				}
+			}
+		}
+	}()
+
 	pterm.Info.Printfln("Executing task %s in Podman sandbox...", payload.TaskID)
 
-	outputDir := w.executePodman(payload.Data, s, s)
+	outputDir := w.executePodman(taskCtx, payload.Data, s, s)
 	defer os.RemoveAll(outputDir)
 
 	if !isDirEmpty(outputDir) {
@@ -121,11 +145,11 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 
 		if err := utils.ZipDirectory(outputDir, zipPath); err == nil {
 			pterm.Info.Println("Routing artifacts to Boss over secure channel...")
-			artifactCtx, cancel := context.WithTimeout(context.Background(), network.ArtifactStreamTimeout)
+			artifactCtx, cancelArtifact := context.WithTimeout(rootCtx, network.ArtifactStreamTimeout)
 			if sendErr := network.SendArtifacts(artifactCtx, w.node.Host, bossID, zipPath, payload.TaskID); sendErr != nil {
 				pterm.Error.Printfln("Failed to route artifacts: %v", sendErr)
 			}
-			cancel()
+			cancelArtifact()
 		} else {
 			pterm.Error.Printfln("Failed to zip artifacts: %v", err)
 		}
@@ -137,7 +161,7 @@ func (w *Worker) handleTaskStream(s netcore.Stream) {
 	reset = false
 }
 
-func (w *Worker) handleFeedbackStream(s netcore.Stream) {
+func (w *Worker) handleFeedbackStream(_ context.Context, s netcore.Stream) {
 	reset := true
 	defer func() {
 		if reset {

--- a/agentfm-go/internal/worker/sandbox.go
+++ b/agentfm-go/internal/worker/sandbox.go
@@ -30,7 +30,8 @@ func (w *Worker) buildSandboxImage() error {
 		return fmt.Errorf("podman build failed: %w", err)
 	}
 
-	pterm.Success.Println("✅ Sandbox Image Built Successfully!\n")
+	pterm.Success.Println("✅ Sandbox Image Built Successfully!")
+	fmt.Println()
 	return nil
 }
 

--- a/agentfm-go/internal/worker/sandbox.go
+++ b/agentfm-go/internal/worker/sandbox.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -33,10 +34,17 @@ func (w *Worker) buildSandboxImage() error {
 	return nil
 }
 
-func (w *Worker) executePodman(prompt string, outStream, errStream io.Writer) string {
+func (w *Worker) executePodman(ctx context.Context, prompt string, outStream, errStream io.Writer) string {
 	sessionID := time.Now().UnixNano()
 	containerName := fmt.Sprintf("agentfm-sandbox-%d", sessionID)
-	defer exec.Command("podman", "rm", "-f", containerName).Run()
+	// Cleanup runs on a detached, bounded ctx so a cancelled parent doesn't
+	// short-circuit the `podman rm -f` that catches orphaned containers
+	// from SIGKILLed `podman run` processes.
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = exec.CommandContext(cleanupCtx, "podman", "rm", "-f", containerName).Run()
+	}()
 
 	baseDir, err := os.Getwd()
 	if err != nil {
@@ -46,8 +54,10 @@ func (w *Worker) executePodman(prompt string, outStream, errStream io.Writer) st
 	agentTempBase := filepath.Join(baseDir, ".agentfm_temp")
 	absOutputDir := filepath.Join(agentTempBase, fmt.Sprintf("run_%d", sessionID))
 
-	os.MkdirAll(absOutputDir, 0777)
-	os.Chmod(absOutputDir, 0777)
+	if err := os.MkdirAll(absOutputDir, 0755); err != nil {
+		fmt.Fprintf(errStream, "❌ Failed to create output dir: %v\n", err)
+		return absOutputDir
+	}
 
 	podmanArgs := []string{"run", "--rm", "--name", containerName, "--network", "host"}
 	hasGPU, _, _, _ := getGPUStats()
@@ -65,14 +75,22 @@ func (w *Worker) executePodman(prompt string, outStream, errStream io.Writer) st
 	podmanArgs = append(podmanArgs, "-e", fmt.Sprintf("AGENTFM_MODEL=%s", w.config.ModelName))
 	podmanArgs = append(podmanArgs, w.config.ImageName, prompt)
 
-	cmd := exec.Command("podman", podmanArgs...)
+	// exec.CommandContext wires ctx cancellation to SIGKILL of the process.
+	// When the task ctx is cancelled (shutdown, stream death, or timeout),
+	// the Podman sandbox is torn down instantly instead of running to
+	// natural completion.
+	cmd := exec.CommandContext(ctx, "podman", podmanArgs...)
 	cmd.Stdout = outStream
 	cmd.Stderr = errStream
 
 	if err := cmd.Start(); err != nil {
 		fmt.Fprintf(errStream, "❌ Failed to start task: %v\n", err)
-	} else {
-		cmd.Wait()
+		return absOutputDir
+	}
+	if err := cmd.Wait(); err != nil {
+		// Non-zero exits and ctx-triggered kills both land here. We surface
+		// the error to the caller's stream so the Boss sees it.
+		fmt.Fprintf(errStream, "⚠️  Sandbox exited: %v\n", err)
 	}
 
 	return absOutputDir

--- a/agentfm-go/internal/worker/telemetry.go
+++ b/agentfm-go/internal/worker/telemetry.go
@@ -26,21 +26,31 @@ func getGPUStats() (hasGPU bool, usedGB float64, totalGB float64, usagePct float
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) > 0 {
-		parts := strings.Split(lines[0], ",")
-		if len(parts) >= 2 {
-			usedMB, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			totalMB, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-
-			usedGB = usedMB / 1024.0
-			totalGB = totalMB / 1024.0
-			if totalGB > 0 {
-				usagePct = (usedGB / totalGB) * 100.0
-			}
-			return true, usedGB, totalGB, usagePct
-		}
+	if len(lines) == 0 {
+		return false, 0, 0, 0
 	}
-	return false, 0, 0, 0
+	parts := strings.Split(lines[0], ",")
+	if len(parts) < 2 {
+		return false, 0, 0, 0
+	}
+
+	// If either number fails to parse the nvidia-smi output is malformed;
+	// treat the probe as a miss rather than publishing garbage telemetry.
+	usedMB, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return false, 0, 0, 0
+	}
+	totalMB, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil {
+		return false, 0, 0, 0
+	}
+
+	usedGB = usedMB / 1024.0
+	totalGB = totalMB / 1024.0
+	if totalGB > 0 {
+		usagePct = (usedGB / totalGB) * 100.0
+	}
+	return true, usedGB, totalGB, usagePct
 }
 
 func (w *Worker) printMetadata() {
@@ -55,11 +65,20 @@ func (w *Worker) printMetadata() {
 func (w *Worker) startTelemetry(ctx context.Context) {
 	topic, err := w.node.PubSub.Join(network.TelemetryTopic)
 	if err != nil {
-		pterm.Fatal.Println(err)
+		// Non-fatal: surface the error and return so parent defers still
+		// run. The worker continues to serve tasks but won't appear on
+		// the radar until it's restarted.
+		pterm.Error.Printfln("Telemetry disabled: failed to join %q topic: %v", network.TelemetryTopic, err)
+		return
 	}
 
 	safeDesc := w.truncateWords(w.config.AgentDesc, 50)
 	totalCores := runtime.NumCPU()
+
+	// Sensor / publish errors are noisy if logged every tick. Track the
+	// last logged message so we only surface changes, not steady-state
+	// failures.
+	var lastSensorErr, lastPublishErr string
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
@@ -69,7 +88,13 @@ func (w *Worker) startTelemetry(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			cpuPercent, _ := cpu.Percent(time.Second, false)
+			cpuPercent, cpuErr := cpu.Percent(time.Second, false)
+			if cpuErr != nil {
+				if msg := cpuErr.Error(); msg != lastSensorErr {
+					pterm.Warning.Printfln("cpu sensor read failed: %v", cpuErr)
+					lastSensorErr = msg
+				}
+			}
 
 			hasGPU, gpuUsed, gpuTotal, gpuPct := getGPUStats()
 
@@ -91,7 +116,13 @@ func (w *Worker) startTelemetry(ctx context.Context) {
 				status = "BUSY"
 			}
 
-			vMem, _ := mem.VirtualMemory()
+			vMem, memErr := mem.VirtualMemory()
+			if memErr != nil {
+				if msg := memErr.Error(); msg != lastSensorErr {
+					pterm.Warning.Printfln("memory sensor read failed: %v", memErr)
+					lastSensorErr = msg
+				}
+			}
 			freeRAM := 0.0
 			if vMem != nil {
 				freeRAM = float64(vMem.Available) / (1024 * 1024 * 1024)
@@ -115,8 +146,19 @@ func (w *Worker) startTelemetry(ctx context.Context) {
 				MaxTasks:     maxTasks,
 			}
 
-			payloadBytes, _ := json.Marshal(profile)
-			topic.Publish(ctx, payloadBytes)
+			payloadBytes, marshalErr := json.Marshal(profile)
+			if marshalErr != nil {
+				pterm.Error.Printfln("failed to marshal telemetry profile: %v", marshalErr)
+				continue
+			}
+			if pubErr := topic.Publish(ctx, payloadBytes); pubErr != nil {
+				if msg := pubErr.Error(); msg != lastPublishErr {
+					pterm.Warning.Printfln("telemetry publish failed: %v", pubErr)
+					lastPublishErr = msg
+				}
+			} else {
+				lastPublishErr = ""
+			}
 
 			if status == "BUSY" {
 				if hasGPU {

--- a/agentfm-go/internal/worker/telemetry.go
+++ b/agentfm-go/internal/worker/telemetry.go
@@ -18,6 +18,14 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
+func (w *Worker) truncateWords(text string, maxWords int) string {
+	words := strings.Fields(text)
+	if len(words) <= maxWords {
+		return text
+	}
+	return strings.Join(words[:maxWords], " ") + "..."
+}
+
 func getGPUStats() (hasGPU bool, usedGB float64, totalGB float64, usagePct float64) {
 	cmd := exec.Command("nvidia-smi", "--query-gpu=memory.used,memory.total", "--format=csv,noheader,nounits")
 	out, err := cmd.Output()

--- a/agentfm-go/internal/worker/worker.go
+++ b/agentfm-go/internal/worker/worker.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -99,12 +98,4 @@ func (w *Worker) waitForShutdown(ctx context.Context) {
 		pterm.Error.Printfln("Host close error: %v", err)
 	}
 	pterm.Success.Println("Safely offline. Goodbye!")
-}
-
-func (w *Worker) truncateWords(text string, maxWords int) string {
-	words := strings.Fields(text)
-	if len(words) <= maxWords {
-		return text
-	}
-	return strings.Join(words[:maxWords], " ") + "..."
 }

--- a/agentfm-go/internal/worker/worker.go
+++ b/agentfm-go/internal/worker/worker.go
@@ -11,6 +11,7 @@ import (
 
 	"agentfm/internal/network"
 
+	netcore "github.com/libp2p/go-libp2p/core/network"
 	"github.com/pterm/pterm"
 )
 
@@ -39,7 +40,7 @@ func New(node *network.MeshNode, cfg Config) *Worker {
 }
 
 // RunLocalTest allows users to test their dockerfile/script locally without libp2p
-func RunLocalTest(cfg Config, prompt string) error {
+func RunLocalTest(ctx context.Context, cfg Config, prompt string) error {
 	w := &Worker{config: cfg}
 
 	if err := w.buildSandboxImage(); err != nil {
@@ -50,7 +51,7 @@ func RunLocalTest(cfg Config, prompt string) error {
 	fmt.Println("--------------------------------------------------")
 
 	// Use os.Stdout for testing locally
-	outputDir := w.executePodman(prompt, os.Stdout, os.Stderr)
+	outputDir := w.executePodman(ctx, prompt, os.Stdout, os.Stderr)
 
 	fmt.Println("\n--------------------------------------------------")
 	pterm.Success.Printfln("✅ Sandbox execution finished.\n📂 Artifacts saved to: %s", outputDir)
@@ -67,27 +68,37 @@ func (w *Worker) Start(ctx context.Context) {
 		os.Exit(1)
 	}
 
+	// Bind the root ctx to OS shutdown signals so every in-flight handler,
+	// including the Podman sub-process it owns, is cancelled when the
+	// operator hits CTRL+C.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	w.printMetadata()
 	go w.startTelemetry(ctx)
 
-	w.node.Host.SetStreamHandler(network.TaskProtocol, w.handleTaskStream)
-	w.node.Host.SetStreamHandler(network.FeedbackProtocol, w.handleFeedbackStream)
+	w.node.Host.SetStreamHandler(network.TaskProtocol, func(s netcore.Stream) {
+		w.handleTaskStream(ctx, s)
+	})
+	w.node.Host.SetStreamHandler(network.FeedbackProtocol, func(s netcore.Stream) {
+		w.handleFeedbackStream(ctx, s)
+	})
 
-	w.waitForShutdown()
+	w.waitForShutdown(ctx)
 }
 
-func (w *Worker) waitForShutdown() {
+func (w *Worker) waitForShutdown(ctx context.Context) {
 	fmt.Println()
 	pterm.Info.Println("Worker is online and listening. Press CTRL+C to cleanly exit.")
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-	<-ch
+
+	<-ctx.Done()
 
 	fmt.Println()
 	pterm.Warning.Println("Received shutdown signal. Disconnecting from the mesh...")
-	w.node.Host.Close()
+	if err := w.node.Host.Close(); err != nil {
+		pterm.Error.Printfln("Host close error: %v", err)
+	}
 	pterm.Success.Println("Safely offline. Goodbye!")
-	os.Exit(0)
 }
 
 func (w *Worker) truncateWords(text string, maxWords int) string {


### PR DESCRIPTION
what got fixed:                                                                                                                                            

  Network / streams                                                                                                                                                       
  - Every libp2p stream now has an explicit deadline set right after accept or dial. Slow-loris peers can't hold Podman slots, HTTP handlers, or file handles open forever
   anymore.                                                                                                                                                               
  - Error paths now Reset() the stream; only the happy path Close()s it. Rejection messages (capacity / CPU / GPU full) still Close gracefully so the peer sees the
  reason.                                                                                                                                                                 
  - Artifact transfer got the same treatment on both sides, plus a per-transfer write deadline.                                                                           
  - Every h.Connect, client.Reserve, FindPeers, and NewStream call is now wrapped in context.WithTimeout(ctx, StreamDialTimeout). No more unbounded context.Background()
  floating around the network layer.                                                                                                                                      
  - mdns callback uses a local bounded ctx now and actually surfaces dial errors.                                                                                         
                                                                                                                                                                          
  Worker / Podman                                                                                                                                                         
  - Podman sandbox now runs via exec.CommandContext, so if the task stream dies or the worker shuts down the container gets SIGKILLed instantly instead of running to
  natural completion.                                                                                                                                                     
  - Added a per-task goroutine that watches s.Conn().IsClosed() and cancels the task ctx if the Boss disappears mid-run.
  - ctx propagates cleanly from Worker.Start (now using signal.NotifyContext) into every handler and the sandbox.                                                         
  - Sandbox output dir moved from 0777 → 0755.                                                                                                                            
  - Dropped cleanup ctx runs independently so shutdown doesn't orphan containers.                                                                                         
                                                                                                                                                                          
  Boss / API gateway                                                                                                                                                      
  - Boss.mu → sync.RWMutex; the two pure-read API existence checks are RLock so concurrent /api/execute hits don't serialise.                                             
  - Async /api/execute/async goroutine is now tracked by a sync.WaitGroup, inherits rootCtx with a TaskExecutionTimeout, and StartAPIServer drains it with a bounded      
  deadline on shutdown.                                                                                                                                                   
  - Webhook POST was the scariest thing in the repo — used the default http.Client with no timeout. Now uses http.NewRequestWithContext + a 30s-timeout client.           
  - http.Server now has ReadHeaderTimeout, ReadTimeout, WriteTimeout, IdleTimeout — slow-loris can't exhaust handler goroutines.                               
  - Server errors route through a channel so main.go owns the exit code; no pterm.Fatal (= os.Exit) from inside goroutines anymore.                                       
                                                                                                                                                                          
  JSON / protocol                                                                                                                                                         
  - Killed the hand-rolled fmt.Sprintf("{...}") JSON in the boss. Any ", \, or newline in a prompt would previously corrupt the envelope and the worker would silently    
  drop the task. Both sides now share a types.TaskPayload struct and use json.Encoder.                                                                                    
                                                                                                                                                                          
  TUI                                                                                                                                                                     
  - Ctrl+C no longer os.Exit(0)s from inside keyboard.Listen. Sets a quit flag instead, defers unwind, and Boss.Run does a clean Host.Close.
                                                                                                                                                                          
  Telemetry
  - pterm.Fatal inside telemetry goroutines (both worker and boss sides) replaced with log + return. Telemetry is now best-effort; the node degrades instead of crashing  
  if pubsub can't join.                                                                                                                                                   
  - getGPUStats returns (false, 0, 0, 0) on malformed nvidia-smi output instead of publishing garbage.
  - Sensor / publish errors de-duped so a persistent failure logs once, not every 2s.                                                                                     
                                                                                                                                                                          
  Cleanup                                                                                                                                                                 
  - Dual-stack listen (v4 + v6) to match the relay binary.                                                                                                                
  - Removed the time.Sleep(2ms) inside every artifact-write chunk — was adding ~2s of latency per MB.                                                                     
  - Killed dead AppVersion const, lifted inline DTO to file scope, preallocated response slice, moved a helper next to its caller.
                                                                                                                                                                          
  Net effect: every footgun the audit called out is gone. go vet ./... is clean. No os.Exit / pterm.Fatal inside any goroutine. No context.Background() outside           
  bounded-timeout or root/boundary cases. Every libp2p stream has a deadline and a defined close/reset policy. Shutdown is now actually graceful end-to-end (SIGINT → root
   ctx cancels → in-flight handlers finish → async WaitGroup drains → Podman containers SIGKILLed → Host.Close).    

code had lots of bad practices .. this should do be good  :)    